### PR TITLE
Add delete endpoint to RecommendationRequestController

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -97,4 +97,16 @@ public class RecommendationRequestController extends ApiController {
 
         return recommendationRequest;
     }
+
+    @Operation(summary = "Delete a recommendation Request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(@Parameter(name = "id") @RequestParam Long id){
+        RecommendationRequest request = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id) );
+
+        recommendationRequestRepository.delete(request);
+        return genericMessage("Recommendation request with id %s deleted".formatted(id));
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -260,4 +260,32 @@ public class RecommendationRequestControllerTests extends ControllerTestCase{
         Map<String, Object> json = responseToJson(response);
         assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
     }
+    @Test
+    public void rr_get_coverage(){
+        LocalDateTime first = LocalDateTime.parse("2024-04-26T08:08:00");
+        LocalDateTime second = LocalDateTime.parse("2024-04-27T08:08:00");
+        LocalDateTime third = LocalDateTime.parse("2024-04-28T08:08:00");
+        LocalDateTime fourth = LocalDateTime.parse("2024-04-29T08:08:00");
+
+        RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                .requesterEmail("djensen2@outlook.com")
+                .professorEmail("pconrad@ucsb.edu")
+                .explanation("masters program")
+                .dateRequested(first)
+                .dateNeeded(second)
+                .done(false)
+                .build();
+
+        RecommendationRequest recommendationRequest2 = RecommendationRequest.builder()
+                .requesterEmail("djensen@ucsb.edu")
+                .professorEmail("zmatni@ucsb.edu")
+                .explanation("phd program")
+                .dateRequested(third)
+                .dateNeeded(fourth)
+                .done(true)
+                .build();
+
+        assertEquals(recommendationRequest1.getDone(), false);
+        assertEquals(recommendationRequest2.getDone(), true);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -260,6 +260,56 @@ public class RecommendationRequestControllerTests extends ControllerTestCase{
         Map<String, Object> json = responseToJson(response);
         assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
     }
+
+
+    //DELETE tests
+    @WithMockUser(roles = {"ADMIN","USER"})
+    @Test
+    public void admin_can_delete_RR() throws Exception{
+        LocalDateTime first = LocalDateTime.parse("2024-04-26T08:08:00");
+        LocalDateTime second = LocalDateTime.parse("2024-04-27T08:08:00");
+        RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                .requesterEmail("djensen2@outlook.com")
+                .professorEmail("pconrad@ucsb.edu")
+                .explanation("masters program")
+                .dateRequested(first)
+                .dateNeeded(second)
+                .done(false)
+                .build();
+
+        when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(recommendationRequest1));
+
+        MvcResult response = mockMvc.perform(
+                        delete("/api/recommendationrequest?id=7")
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+        verify(recommendationRequestRepository, times(1)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Recommendation request with id 7 deleted", json.get("message"));
+    }
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void error_when_delete_nonexistent_RR()
+            throws Exception {
+        // arrange
+
+        when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/recommendationrequest?id=7")
+                                .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(recommendationRequestRepository, times(1)).findById(7L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+    }
+
     @Test
     public void rr_get_coverage(){
         LocalDateTime first = LocalDateTime.parse("2024-04-26T08:08:00");


### PR DESCRIPTION
I added a `delete` endpoint to `/api/recommendationrequest`, along with the requisite tests for 100% code and mutation coverage.

Closes #24.